### PR TITLE
fix(unit-test): rewrite the dummy torque value

### DIFF
--- a/test/unit/dummies/tmc2209/tmc2209.c
+++ b/test/unit/dummies/tmc2209/tmc2209.c
@@ -6,6 +6,7 @@
 
 #include "tmc2209.h"
 uint64_t CURRENT_VELOCITY;
+uint32_t count = 1000;
 
 void TMC2209_setup(TMC2209_t *tmc2209, serialUart_t serial, long serial_baud_rate,
                    SerialAddress_t serial_address) {
@@ -32,7 +33,11 @@ void TMC2209_setRunCurrent(TMC2209_t *tmc2209, uint8_t percent) {}
 void TMC2209_setHoldCurrent(TMC2209_t *tmc2209, uint8_t percent) {}
 
 uint16_t TMC2209_getStallGuardResult(TMC2209_t *tmc2209) {
-    return 0;
+    if (count == 0) {
+        count = 1000;
+    }
+    count--;
+    return count;
 }
 
 void TMC2209_moveAtVelocity(TMC2209_t *tmc2209, int32_t microsteps_per_period) {

--- a/test/unit/test_dispenser.c
+++ b/test/unit/test_dispenser.c
@@ -8,13 +8,11 @@ void setUp() {}
 void tearDown() {}
 
 void testDispenserStructChanged(void) {
-    // TODO: FIXME I'm failing
     // If Fails, struct was changed and tests need to be adjusted
     TEST_ASSERT_EQUAL(40, sizeof(dispenser_t));
 }
 
 void test_Dispenser_should_sleep(void) {
-    // TODO: FIXME I'm failing
     dispenser_t dispenser[1];
     dispenserCreate(&dispenser[0], 0, 4);
     dispenserStateCode_t state = getDispenserState(&dispenser[0]);
@@ -22,7 +20,6 @@ void test_Dispenser_should_sleep(void) {
 }
 
 void test_Dispenser_Cycle(void) {
-    // TODO: FIXME I'm failing
     dispenser_t dispenser[1];
     dispenserCreate(&dispenser[0], 0, 4);
     dispenserSetHaltTime(&dispenser[0], 10);

--- a/test/unit/test_dispenser.c
+++ b/test/unit/test_dispenser.c
@@ -10,7 +10,7 @@ void tearDown() {}
 void testDispenserStructChanged(void) {
     // TODO: FIXME I'm failing
     // If Fails, struct was changed and tests need to be adjusted
-    TEST_ASSERT_EQUAL(24, sizeof(dispenser_t));
+    TEST_ASSERT_EQUAL(40, sizeof(dispenser_t));
 }
 
 void test_Dispenser_should_sleep(void) {


### PR DESCRIPTION
The unit_test_dispenser should work now.