### PR TITLE
delete the redundant TMC2209_moveAtVelocity functions

### DIFF
--- a/src/motor/motor.c
+++ b/src/motor/motor.c
@@ -69,24 +69,19 @@ uint16_t motorGetTorque(motorAddress_t address) {
 void moveMotorUp(motorAddress_t address) {
     Motor_t *motor = getMotor(address);
     TMC2209_moveAtVelocity(&motor->tmc2209, motor->direction * MOTOR_UP_SPEED);
-    TMC2209_moveAtVelocity(&motor->tmc2209, motor->direction * MOTOR_UP_SPEED);
 }
 
 void moveMotorUpSlowSpeed(motorAddress_t address) {
     Motor_t *motor = getMotor(address);
-    TMC2209_moveAtVelocity(&motor->tmc2209, motor->direction * MOTOR_UP_SPEED_SLOW);
     TMC2209_moveAtVelocity(&motor->tmc2209, motor->direction * MOTOR_UP_SPEED_SLOW);
 }
 
 void moveMotorDown(motorAddress_t address) {
     Motor_t *motor = getMotor(address);
     TMC2209_moveAtVelocity(&motor->tmc2209, motor->direction * -MOTOR_DOWN_SPEED);
-    TMC2209_moveAtVelocity(&motor->tmc2209, motor->direction * -MOTOR_DOWN_SPEED);
 }
 
 void stopMotor(motorAddress_t address) {
     Motor_t *motor = getMotor(address);
     TMC2209_moveAtVelocity(&motor->tmc2209, 0);
-    TMC2209_moveAtVelocity(&motor->tmc2209, 0);
 }
-// maybe we should change the names of TMC2209_moveAtVelocity


### PR DESCRIPTION
With some tests of the motor-related functions I found that now we can use singe TMC2209_moveAtVelocity function to make motor work normally.
![4474ea51b50d879f194d205887bf4d0](https://github.com/ES-EDU-SIEGMA/Embedded-Controller/assets/148549041/d59c1ed4-6115-4d09-a778-f93fe35759b4)
